### PR TITLE
Add simple Forge/ComfyUI manager

### DIFF
--- a/appm/app.js
+++ b/appm/app.js
@@ -1,68 +1,83 @@
 const express = require('express');
-const { exec } = require('child_process');
+const { exec, spawn } = require('child_process');
+const path = require('path');
 const app = express();
 const PORT = 8000;
 
-app.use(express.static('public'));
+app.use(express.static(path.join(__dirname, 'public')));
 
-app.get('/stop_a1111', (req, res) => {
-    exec('fuser -k 3001/tcp', (error, stdout, stderr) => {
+function startScript(scriptPath) {
+    exec(`bash ${scriptPath} &`, (error) => {
         if (error) {
-            console.error(`Error stopping A1111: ${error}`);
+            console.error(`Error running ${scriptPath}: ${error}`);
         }
     });
+}
 
-    res.send('Stopped A1111 successfully!');
+// Forge routes
+app.get('/start_forge', (req, res) => {
+    startScript(path.join(__dirname, 'scripts/start_forge.sh'));
+    res.send('Started Forge successfully!');
 });
 
-app.get('/start_a1111', (req, res) => {
-    exec('scripts/start_a1111.sh &', (error, stdout, stderr) => {
-        if (error) {
-            console.error(`Error starting A1111: ${error}`);
-        }
+app.get('/stop_forge', (req, res) => {
+    exec('fuser -k 3000/tcp', (error) => {
+        if (error) console.error(`Error stopping Forge: ${error}`);
     });
-
-    res.send('Started A1111 successfully!');
+    res.send('Stopped Forge successfully!');
 });
 
-app.get('/stop_kohya', (req, res) => {
-    exec('fuser -k 3011/tcp', (error, stdout, stderr) => {
-        if (error) {
-            console.error(`Error stopping Kohya_ss: ${error}`);
-        }
+app.get('/restart_forge', (req, res) => {
+    exec('fuser -k 3000/tcp', (error) => {
+        if (error) console.error(`Error stopping Forge: ${error}`);
+        startScript(path.join(__dirname, 'scripts/start_forge.sh'));
     });
-
-    res.send('Stopped Kohya_ss successfully!');
+    res.send('Restarted Forge successfully!');
 });
 
-app.get('/start_kohya', (req, res) => {
-    exec('scripts/start_kohya.sh &', (error, stdout, stderr) => {
-        if (error) {
-            console.error(`Error starting Kohya_ss: ${error}`);
-        }
-    });
-
-    res.send('Started Kohya_ss successfully!');
+// ComfyUI routes
+app.get('/start_comfyui', (req, res) => {
+    startScript(path.join(__dirname, 'scripts/start_comfyui.sh'));
+    res.send('Started ComfyUI successfully!');
 });
 
 app.get('/stop_comfyui', (req, res) => {
-    exec('fuser -k 3021/tcp', (error, stdout, stderr) => {
-        if (error) {
-            console.error(`Error stopping ComfyUI: ${error}`);
-        }
+    exec('fuser -k 7860/tcp', (error) => {
+        if (error) console.error(`Error stopping ComfyUI: ${error}`);
     });
-
     res.send('Stopped ComfyUI successfully!');
 });
 
-app.get('/start_comfyui', (req, res) => {
-    exec('scripts/start_comfyui.sh &', (error, stdout, stderr) => {
-        if (error) {
-            console.error(`Error starting ComfyUI: ${error}`);
-        }
+app.get('/restart_comfyui', (req, res) => {
+    exec('fuser -k 7860/tcp', (error) => {
+        if (error) console.error(`Error stopping ComfyUI: ${error}`);
+        startScript(path.join(__dirname, 'scripts/start_comfyui.sh'));
     });
+    res.send('Restarted ComfyUI successfully!');
+});
 
-    res.send('Started ComfyUI successfully!');
+function streamLog(req, res, logPath) {
+    res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive'
+    });
+    const tail = spawn('tail', ['-n', '20', '-F', logPath]);
+    tail.stdout.on('data', data => {
+        res.write(`data: ${data}\n\n`);
+    });
+    tail.stderr.on('data', data => {
+        res.write(`data: ${data}\n\n`);
+    });
+    req.on('close', () => tail.kill());
+}
+
+app.get('/logs/forge', (req, res) => {
+    streamLog(req, res, '/workspace/logs/forge.log');
+});
+
+app.get('/logs/comfyui', (req, res) => {
+    streamLog(req, res, '/workspace/logs/comfyui.log');
 });
 
 app.listen(PORT, '0.0.0.0', () => {

--- a/appm/public/index.html
+++ b/appm/public/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="/style.css" />
@@ -21,33 +20,36 @@
             </thead>
             <tbody>
             <tr>
-                <td>A1111</td>
+                <td>Forge</td>
                 <td>
-                    <button id="stopA111" class="btn btn-danger">Stop</button>
-                    <button id="startA111" class="btn btn-success">Start</button>
-                </td>
-            </tr>
-            <tr>
-                <td>Kohya_ss</td>
-                <td>
-                    <button id="stopKohya" class="btn btn-danger">Stop</button>
-                    <button id="startKohya" class="btn btn-success">Start</button>
+                    <button id="startForge" class="btn btn-success">Start</button>
+                    <button id="stopForge" class="btn btn-danger">Stop</button>
+                    <button id="restartForge" class="btn btn-warning">Restart</button>
                 </td>
             </tr>
             <tr>
                 <td>ComfyUI</td>
                 <td>
-                    <button id="stopComfyUI" class="btn btn-danger">Stop</button>
-                    <button id="startComfyUI" class="btn btn-success">Start</button>
+                    <button id="startComfy" class="btn btn-success">Start</button>
+                    <button id="stopComfy" class="btn btn-danger">Stop</button>
+                    <button id="restartComfy" class="btn btn-warning">Restart</button>
                 </td>
             </tr>
             </tbody>
         </table>
     </div>
+    <div class="row mt-4">
+        <div class="col-md-6">
+            <h5 class="text-center">Forge Logs</h5>
+            <pre id="forgeLogs" class="log-viewer"></pre>
+        </div>
+        <div class="col-md-6">
+            <h5 class="text-center">ComfyUI Logs</h5>
+            <pre id="comfyLogs" class="log-viewer"></pre>
+        </div>
+    </div>
 </div>
-
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-<script src="https://code.jquery.com/ui/1.13.0/jquery-ui.min.js"></script>
 <script src="/script.js"></script>
 </body>
 </html>

--- a/appm/public/script.js
+++ b/appm/public/script.js
@@ -1,37 +1,35 @@
 $(document).ready(function() {
-        $('#stopA111').click(function() {
-            $.get('/stop_a1111', function(data) {
-                alert(data);
-            });
-        });
-
-        $('#startA111').click(function() {
-            $.get('/start_a1111', function(data) {
-                alert(data);
-            });
-        });
-
-        $('#stopKohya').click(function() {
-            $.get('/stop_kohya', function(data) {
-                alert(data);
-            });
-        });
-
-        $('#startKohya').click(function() {
-            $.get('/start_kohya', function(data) {
-                alert(data);
-            });
-        });
-
-        $('#stopComfyUI').click(function() {
-            $.get('/stop_comfyui', function(data) {
-                alert(data);
-            });
-        });
-
-        $('#startComfyUI').click(function() {
-            $.get('/start_comfyui', function(data) {
-                alert(data);
-            });
-        });
+    $('#startForge').click(function() {
+        $.get('/start_forge', alert);
     });
+    $('#stopForge').click(function() {
+        $.get('/stop_forge', alert);
+    });
+    $('#restartForge').click(function() {
+        $.get('/restart_forge', alert);
+    });
+
+    $('#startComfy').click(function() {
+        $.get('/start_comfyui', alert);
+    });
+    $('#stopComfy').click(function() {
+        $.get('/stop_comfyui', alert);
+    });
+    $('#restartComfy').click(function() {
+        $.get('/restart_comfyui', alert);
+    });
+
+    const forgeSource = new EventSource('/logs/forge');
+    forgeSource.onmessage = function(event) {
+        const log = $('#forgeLogs');
+        log.append(event.data + '\n');
+        log.scrollTop(log[0].scrollHeight);
+    };
+
+    const comfySource = new EventSource('/logs/comfyui');
+    comfySource.onmessage = function(event) {
+        const log = $('#comfyLogs');
+        log.append(event.data + '\n');
+        log.scrollTop(log[0].scrollHeight);
+    };
+});

--- a/appm/public/style.css
+++ b/appm/public/style.css
@@ -32,3 +32,11 @@ thead.thead-dark {
     border-color: #9d0208;
 }
 
+.log-viewer {
+    background-color: rgba(0,0,0,0.6);
+    color: #0f0;
+    height: 200px;
+    overflow-y: scroll;
+    padding: 10px;
+    font-size: 0.85rem;
+}

--- a/appm/scripts/start_a1111.sh
+++ b/appm/scripts/start_a1111.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-cd /workspace/stable-diffusion-webui && nohup ./webui.sh -f > /workspace/logs/webui.log 2>&1 &

--- a/appm/scripts/start_comfyui.sh
+++ b/appm/scripts/start_comfyui.sh
@@ -1,2 +1,9 @@
 #!/usr/bin/env bash
-cd /workspace/ComfyUI && source venv/bin/activate && python3 main.py --listen 0.0.0.0 --port 3021 > /workspace/logs/comfyui.log 2>&1 &
+# Launch ComfyUI with the same arguments used on container start
+cd /workspace/comfyui || exit 1
+source venv/bin/activate
+nohup python main.py --listen 0.0.0.0 --port 7860 \
+    --extra-model-paths-config /workspace/comfyui/extra_model_paths.yaml \
+    --highvram --cuda-malloc > /workspace/logs/comfyui.log 2>&1 &
+deactivate
+

--- a/appm/scripts/start_forge.sh
+++ b/appm/scripts/start_forge.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Launch Forge with the same arguments used on container start
+cd /workspace/stable-diffusion-webui || exit 1
+source venv/bin/activate
+nohup python launch.py --listen --port 3000 --api \
+    --enable-insecure-extension-access --cuda-malloc --opt-sdp-attention \
+    > /workspace/logs/forge.log 2>&1 &
+deactivate
+

--- a/appm/scripts/start_kohya.sh
+++ b/appm/scripts/start_kohya.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-cd /workspace/kohya_ss && nohup ./gui.sh --listen 0.0.0.0 --server_port 3011 --headless --share > /workspace/logs/kohya_ss.log 2>&1 &

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -297,6 +297,13 @@ start_comfyui() {
     deactivate
 }
 
+start_app_manager() {
+    echo "APPM: Starting App Manager..."
+    cd /workspace/appm || return
+    nohup node app.js &> /workspace/logs/appm.log &
+    echo "APPM: App Manager started"
+}
+
 
 
 
@@ -317,6 +324,7 @@ check_python_version
 export_env_vars
 start_forge
 start_comfyui
+start_app_manager
 execute_script "/post_start.sh" "POST-START: Running post-start script..."
 echo "Container is READY!"
 sleep infinity


### PR DESCRIPTION
## Summary
- clean up app.js to manage only Forge and ComfyUI
- add restart routes and log streaming over SSE
- create start scripts mirroring container startup commands
- remove unused A1111 and Kohya scripts
- start the app manager alongside other services on container launch

## Testing
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_687c0d4864a88325acae832b1a84caf6